### PR TITLE
Fix Gradle 8.0 Namespace Required

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+	namespace "party.bent.millimeters"
+
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
When using the package in a Flutter app with gradle 8.0 (which in my case because I migrated using AGP), the build process complains about namespace not specified in the package.


```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':millimeters'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1s
Error: Gradle task assembleDevelopmentDebug failed with exit code 1

Exited (1).
```

Feel free to change the namespace later, I just copied paste the Android package name